### PR TITLE
Make casing consistent

### DIFF
--- a/src/design_patterns/specification/README.md
+++ b/src/design_patterns/specification/README.md
@@ -103,7 +103,7 @@ into a single variable, which can be easily replaced?
 
 This is where the specification pattern comes in!
 
-## Best practice
+## Best Practice
 
 ### Starting at the end
 

--- a/src/design_principles/solid/liskov/README.md
+++ b/src/design_principles/solid/liskov/README.md
@@ -41,7 +41,7 @@ a Square is _technically_ a rectangle as revealed by a simple Google search:
 So how could this be a problem when programming? Let's take a look at the violation
 in `example.py`.
 
-### Simple Example
+### Simple example
 
 If we look at the `Rectangle` and `Square` classes, they make sense in terms of our
 natural language representation. The square is a subtype of rectangle and the

--- a/src/design_principles/solid/liskov/detailed/ParameterTypes.md
+++ b/src/design_principles/solid/liskov/detailed/ParameterTypes.md
@@ -23,7 +23,7 @@ Yeah, that didn't make it clearer for me either - so let's take a look at the ex
 Rather than walk through the full code in the usual order, I will present the code
 in an order which helps highlight the problem first.
 
-### The Problem
+### The problem
 
 Let's say we have a class, `LivingRoom` which looks like the following:
 
@@ -138,7 +138,7 @@ Because of this violation, although we'd expect that second test to work, it doe
 because the more specific parameter type `ConsoleGame` makes use of a property
 `supported_console` which doesn't exist in the more generic `VideoGame`.
 
-### The Solution
+### The solution
 
 Preventing this issue is simple. In our example, the `ConsoleGamer` should not have
 changed the `game: VideoGame` parameter to the more specific `game: ConsoleGame` type.

--- a/src/design_principles/solid/liskov/detailed/ReturnTypes.md
+++ b/src/design_principles/solid/liskov/detailed/ReturnTypes.md
@@ -19,7 +19,7 @@ we learnt that the subclass method must have arguments that match, or are more a
 than the superclass. But here, we learn that the subclass method should have a return
 type that matches, or is more specific than the superclass.
 
-### The Problem
+### The problem
 
 Before we start, let's remind ourselves of the core idea of the Liskov substitution 
 principle (LSP), which is that:
@@ -72,7 +72,7 @@ So in our case, the `.save()` method is only implemented in `VideoGame`. This
 hopefully highlights why the return types cannot be more abstract than the parent 
 class.
 
-### The Solution
+### The solution
 
 The return type should match, or be more specific. So our
 `IndieGameRentalStore.rent_game()` should return either a `VideoGame` instance or 


### PR DESCRIPTION
Using title case for H1 & H2, and sentence case for anything lower.